### PR TITLE
Changed scratch-gui to local-scratch-gui

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# scratch-gui
+# local-scratch-gui
 #### Scratch GUI is a set of React components that comprise the interface for creating and running Scratch 3.0 projects
 
 ## Installation


### PR DESCRIPTION
### Proposed Changes

This pull request edits the README.md to sat "local-scratch-gui" instead of "scratch-gui"

### Reason for Changes

This is a local copy, not the actual scratch-gui